### PR TITLE
Add SpellCast to list of IDs

### DIFF
--- a/discordTogether/discordTogetherMain.py
+++ b/discordTogether/discordTogetherMain.py
@@ -13,7 +13,8 @@ defaultApplications = {
     # Credits to awesomehet2124
     'letter-tile': '879863686565621790',
     'word-snack': '879863976006127627',
-    'doodle-crew': '878067389634314250'
+    'doodle-crew': '878067389634314250',
+    'spellcast': '852509694341283871'
 }
 
 


### PR DESCRIPTION
Discord recently added a new game called SpellCast so I found the ID and added it to use with my bot